### PR TITLE
Rename from nyx.js -> @malleatus/nyx

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "nyx.js",
+  "name": "@malleatus/nyx",
   "version": "0.1.0",
-  "repository": "https://github.com/hjdivad/nyx.js.git",
+  "repository": "https://github.com/malleatus/nyx.git",
   "license": "MIT",
   "author": "David J. Hamilton <dhamilton@linkedin.com>",
   "contributors": [
@@ -44,6 +44,7 @@
     "node": "10.* || >= 12.*"
   },
   "publishConfig": {
+    "access": "public",
     "registry": "https://registry.npmjs.org"
   },
   "release-it": {

--- a/src/commands/report-failure.ts
+++ b/src/commands/report-failure.ts
@@ -52,7 +52,7 @@ export default async function reportFailure({ env }: MainArgs) {
 
   const github = new Octokit({
     auth: token,
-    userAgent: 'nyx.js nightly tests issue reporter',
+    userAgent: '@malleatus/nyx failure reporter',
   });
 
   const issueTitle = getIssueTitle(runId);


### PR DESCRIPTION
* Update name of package
* Add public access control (avoids a prompt when publishing new scoped package)
* Move repo from `malleatus/nyx.js` to `malleatus/nyx`
* Update user agent to `@malleatus/nyx`