### PR TITLE
Add `build:clean` script (and run it from `yarn build`).

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
   "main": "dist/index.js",
   "bin": "./dist/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "npm-run-all build:clean build:ts",
+    "build:clean": "rimraf dist",
+    "build:ts": "tsc",
     "build:watch": "tsc --watch",
     "lint": "eslint --cache . --ext js,ts",
-    "test": "npm-run-all lint test:jest",
+    "test": "npm-run-all lint build test:jest",
     "test:jest": "jest"
   },
   "dependencies": {
@@ -37,6 +39,7 @@
     "prettier": "^1.19.1",
     "release-it": "^13.0.2",
     "release-it-lerna-changelog": "^2.0.0",
+    "rimraf": "^3.0.2",
     "ts-jest": "^25.2.1",
     "typescript": "~3.8.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4686,7 +4686,7 @@ rimraf@^2.5.4, rimraf@^2.6.3, rimraf@^2.7.1:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.0:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==


### PR DESCRIPTION
This ensures that `yarn build` clears `dist/` prior to running `tsc`.