### PR TITLE
Avoid linting in `test` CI job.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: yarn install
         run: yarn --frozen-lockfile --install
       - name: test
-        run: yarn test
+        run: yarn test:jest
 
   test-node:
     name: 'node:${{matrix.node}}' # rely on matrix for most of name
@@ -48,4 +48,4 @@ jobs:
       - name: yarn install
         run: yarn --frozen-lockfile --install
       - name: test
-        run: yarn test
+        run: yarn test:jest


### PR DESCRIPTION
We have a few different CI jobs setup:

* linting -> runs `yarn lint`
* test -> runs `yarn test`
* test-node -> runs `yarn test` for many Node versions

Because `yarn test` should **always** be the source of truth for "pass vs fail" of a project, we have also setup `yarn test` to run `yarn lint`. As you can see, this means that we are _actually_ running linting in **all** of our test jobs now. 🥳

This updates the non-linting jobs to run `test:jest` directly (and avoid running linting for every job).