### PR TITLE
Prevent TypeScript from compiling down to ES5.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2018",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
This updates to target ES2017, which results in much fewer things being
transpiled.