### PR TITLE
Use @typescript-eslint/eslint-parser's recommended set of linting rules.

### DIFF
--- a/.eslintrc.base.js
+++ b/.eslintrc.base.js
@@ -8,7 +8,7 @@ module.exports = {
   plugins: ['@typescript-eslint', 'node'],
   extends: [
     'eslint:recommended',
-    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended',
     'plugin:node/recommended',
   ],
   env: {

--- a/src/commands/report-failure.ts
+++ b/src/commands/report-failure.ts
@@ -10,7 +10,7 @@ function assert(value: unknown, message: string): asserts value {
   }
 }
 
-function getIssueTitle(runId: string) {
+function getIssueTitle(runId: string): string {
   return `Nightly Run Failure: ${runId}`;
 }
 
@@ -24,7 +24,7 @@ interface CreateIssueArgs {
 
 // TODO: report commit range
 // TODO: even more betterer bisect commit range (possibly as a separate workflow)
-async function createIssue({ github, runId, owner, repo }: CreateIssueArgs) {
+async function createIssue({ github, runId, owner, repo }: CreateIssueArgs): Promise<void> {
   const title = getIssueTitle(runId);
   const date = m().format('D MMM YYYY');
   const url = `https://github.com/${owner}/${repo}/actions/runs/${runId}`;
@@ -42,7 +42,7 @@ async function createIssue({ github, runId, owner, repo }: CreateIssueArgs) {
 interface MainArgs {
   env: NodeJS.ProcessEnv;
 }
-export default async function reportFailure({ env }: MainArgs) {
+export default async function reportFailure({ env }: MainArgs): Promise<void> {
   const { GITHUB_TOKEN: token, RUN_ID: runId, OWNER: owner, REPO: repo } = env;
 
   assert(!!token, `env GITHUB_TOKEN must be set`);


### PR DESCRIPTION
A few of these rules are slightly annoying (e.g. explicit return type), but without using it's  `recommended` set we have maintanence issues as we update eslint versions. We'd also have to manually manage the specific built-in rules to disable (e.g. `no-unused-vars` in favor of `@typescript-eslint/no-unused-vars` which is type aware).

I think overall, the balance is actually in the side of using `@typescript-eslint/recommended`.

Closes #6