### PR TITLE
Prevent `jest` from running tests twice upon `yarn test`.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  roots: ['<rootDir>/src/'],
 };


### PR DESCRIPTION
Prior to this change, we ran all of our `src/**/*.test.ts` files twice (once in `dist/` and once in `src/`), this change prevents double running by only running the tests in `src/**/*.test.ts`.

As part of `yarn test` we run `tsc` which compiles `src/` into `dist/`.  Just after that compilation, we run tests with `jest`. The default configuration for `jest` will look for test files throughout the full project working directory (which is a great default IMHO), but in our configuration we have told `jest` how to handle `.ts` files _and_ `.js` files. This results in running the test files both in `dist/` and in `src/`.