### PR TITLE
Ensure eslint-plugin-node knows the final compiled paths.

### DIFF
--- a/.eslintrc.base.js
+++ b/.eslintrc.base.js
@@ -35,6 +35,13 @@ module.exports = {
       settings: {
         node: {
           tryExtensions: ['.js', '.json', '.d.ts', '.ts'],
+
+          convertPath: [
+            {
+              include: ['src/**/*.ts'],
+              replace: ['^src/(.+)\\.ts$', 'dist/$1.js'],
+            },
+          ],
         },
       },
       rules: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import * as yargs from 'yargs';
 import setupHardRejection from 'hard-rejection';
 import reportFailure from './commands/report-failure';


### PR DESCRIPTION
In order for eslint-plugin-node's rules to work properly they need to be able to understand how a given file in `src/` maps to the published package output.

A few examples:

* `node/no-unpublished-import` needs to be able to understand the `files` listing in `package.json` to determine if a given file in `src/` will or will not be included in the final published package (so that it can fail when you import something from a `devDependencies` because it won't be present when published)
* `node/shebang` needs to understand when a given file is used as a `bin/` script in the `package.json` so that it can know which usages of `#!` are valid and which aren't.

Closes #15 