### PR TITLE
Migrate to using parsed arguments (instead of environment variables).

### DIFF
--- a/src/commands/report-failure.test.ts
+++ b/src/commands/report-failure.test.ts
@@ -100,12 +100,10 @@ describe('src/commands/report-failure.ts', function () {
     expect(issues.data.length).toEqual(0);
 
     await reportFailure({
-      env: {
-        OWNER: 'malleatus',
-        REPO: 'nyx-example',
-        RUN_ID: '123456',
-        GITHUB_TOKEN: GITHUB_AUTH || 'fake-auth-token',
-      },
+      owner: 'malleatus',
+      repo: 'nyx-example',
+      runId: '123456',
+      token: GITHUB_AUTH || 'fake-auth-token',
     });
 
     issues = await github.issues.listForRepo({

--- a/src/commands/report-failure.ts
+++ b/src/commands/report-failure.ts
@@ -1,14 +1,7 @@
 // https://octokit.github.io/rest.js/v17#issues-list
 import { Octokit } from '@octokit/rest';
 import m from 'moment';
-
-// TODO: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42786
-// import * as assert from 'assert';
-function assert(value: unknown, message: string): asserts value {
-  if (!value) {
-    throw new Error(message);
-  }
-}
+import assert from '../utils/assert';
 
 function getIssueTitle(runId: string): string {
   return `Nightly Run Failure: ${runId}`;

--- a/src/commands/report-failure.ts
+++ b/src/commands/report-failure.ts
@@ -1,7 +1,6 @@
 // https://octokit.github.io/rest.js/v17#issues-list
 import { Octokit } from '@octokit/rest';
 import m from 'moment';
-import assert from '../utils/assert';
 
 function getIssueTitle(runId: string): string {
   return `Nightly Run Failure: ${runId}`;
@@ -32,16 +31,18 @@ async function createIssue({ github, runId, owner, repo }: CreateIssueArgs): Pro
 }
 
 interface MainArgs {
-  env: NodeJS.ProcessEnv;
+  owner: string;
+  repo: string;
+  runId: string;
+  token: string;
 }
-export default async function reportFailure({ env }: MainArgs): Promise<void> {
-  const { GITHUB_TOKEN: token, RUN_ID: runId, OWNER: owner, REPO: repo } = env;
 
-  assert(!!token, `env GITHUB_TOKEN must be set`);
-  assert(!!runId, `env RUN_ID must be set`);
-  assert(!!owner, `env OWNER must be set`);
-  assert(!!repo, `env REPO must be set`);
-
+export default async function reportFailure({
+  owner,
+  repo,
+  token,
+  runId,
+}: MainArgs): Promise<void> {
   const github = new Octokit({
     auth: token,
     userAgent: '@malleatus/nyx failure reporter',

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import * as yargs from 'yargs';
 import setupHardRejection from 'hard-rejection';
 import reportFailure from './commands/report-failure';
+import assert from './utils/assert';
 
 setupHardRejection();
 
@@ -16,8 +17,18 @@ yargs
       // setup command options
     },
     async function () {
+      const { GITHUB_TOKEN: token, RUN_ID: runId, OWNER: owner, REPO: repo } = process.env;
+
+      assert(!!token, `env GITHUB_TOKEN must be set`);
+      assert(!!runId, `env RUN_ID must be set`);
+      assert(!!owner, `env OWNER must be set`);
+      assert(!!repo, `env REPO must be set`);
+
       reportFailure({
-        env: process.env,
+        owner,
+        repo,
+        runId,
+        token,
       });
     }
   )

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -1,6 +1,6 @@
 // TODO: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42786
 // import * as assert from 'assert';
-export default function assert(value: unknown, message: string): asserts value {
+export default function assert<T>(value: unknown, message: string): asserts value {
   if (!value) {
     throw new Error(message);
   }

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -1,0 +1,7 @@
+// TODO: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42786
+// import * as assert from 'assert';
+export default function assert(value: unknown, message: string): asserts value {
+  if (!value) {
+    throw new Error(message);
+  }
+}


### PR DESCRIPTION
Running `node dist/index.js` emits the following help text:

``` nyx <cmd> [args]

Commands:
 nyx report-failure  opens an issue on the specified repo to report a failure

Options:
 --version  Show version number                                      [boolean]
 --help     Show help                                                [boolean]
```

And `node dist/index.js report-failure` emits:

``` nyx report-failure

opens an issue on the specified repo to report a failure

Options:
 --version    Show version number                                    [boolean]
 --help       Show help                                              [boolean]
 --owner, -o  The organization or user for the repository   [string] [required]
 --repo, -r   The repository name                           [string] [required]
 --run-id     The GitHub actions run id to report failing   [string] [required]
 --token      The GitHub token to use to open the issue, will use $GITHUB_AUTH
              if this option is not specified                         [string]

Missing required arguments: owner, repo, run-id
```