### PR TITLE
Speed up linting and lint-staged.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
-**/node_modules/**
-**/dist/**
 !.*
+node_modules/
+dist/
+.git/

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "lint-staged": {
-    "*.{js,ts}": "yarn lint"
+    "*.{js,ts}": "eslint --ext js,ts"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
See individual commit messages for more details, but on a high level this speeds up running `./node_modules/.bin/lint-staged` from 2s to about 1.5s (averaged over 10 runs).