### PR TITLE
Stop Erroneously creating new nightly issues

### DIFF
--- a/.recordings/basic-test_3799535060/recording.har
+++ b/.recordings/basic-test_3799535060/recording.har
@@ -8,6 +8,365 @@
     },
     "entries": [
       {
+        "_id": "43e71ef60d7813d665f5b60e1eb1c867",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/vnd.github.v3+json"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@malleatus/nyx failure reporter octokit-rest.js/17.11.2 octokit-core.js/2.5.4 Node.js/12.16.1 (macOS Big Sur; x64)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "api.github.com"
+            }
+          ],
+          "headersSize": 475,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "q",
+              "value": "repo:malleatus/nyx-example state:open is:issue label:CI in:title \"Nightly Run Failure\""
+            }
+          ],
+          "url": "https://api.github.com/search/issues?q=repo%3Amalleatus%2Fnyx-example%20state%3Aopen%20is%3Aissue%20label%3ACI%20in%3Atitle%20%22Nightly%20Run%20Failure%22"
+        },
+        "response": {
+          "bodySize": 148,
+          "content": {
+            "_isBinary": true,
+            "mimeType": "application/json; charset=utf-8",
+            "size": 148,
+            "text": "[\"1f8b0800000000000003ab562ac92f49cc894fce2fcd2b51b232d051cacc4bcecf2dc8492d498d2f4a2d2ecd292956b24a4bcc294e054a95a4e60279d1b1b500c845f5b737000000\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "server",
+              "value": "GitHub.com"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 29 Jul 2021 20:13:41 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "vary",
+              "value": "Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept, X-Requested-With"
+            },
+            {
+              "name": "x-oauth-scopes",
+              "value": "repo"
+            },
+            {
+              "name": "x-accepted-oauth-scopes",
+              "value": ""
+            },
+            {
+              "name": "x-github-media-type",
+              "value": "github.v3; format=json"
+            },
+            {
+              "name": "x-ratelimit-limit",
+              "value": "30"
+            },
+            {
+              "name": "x-ratelimit-remaining",
+              "value": "29"
+            },
+            {
+              "name": "x-ratelimit-reset",
+              "value": "1627589681"
+            },
+            {
+              "name": "x-ratelimit-used",
+              "value": "1"
+            },
+            {
+              "name": "x-ratelimit-resource",
+              "value": "search"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubdomains; preload"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "deny"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "0"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "origin-when-cross-origin, strict-origin-when-cross-origin"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none'"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "x-github-request-id",
+              "value": "AABD:4584:F7A89A:229947A:61030BF4"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 1162,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "1994-04-03T13:14:00.000Z",
+        "time": 0,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 0
+        }
+      },
+      {
+        "_id": "23338d6c037407fc93437c1ada5aebb5",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 160,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/vnd.github.v3+json"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "@malleatus/nyx failure reporter octokit-rest.js/17.11.2 octokit-core.js/2.5.4 Node.js/12.16.1 (macOS Big Sur; x64)"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "160"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "api.github.com"
+            }
+          ],
+          "headersSize": 446,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"title\":\"Nightly Run Failure: 123456\",\"body\":\"Nightly run failed on: 3 Apr 1994\\nhttps://github.com/malleatus/nyx-example/actions/runs/123456\",\"labels\":[\"CI\"]}"
+          },
+          "queryString": [],
+          "url": "https://api.github.com/repos/malleatus/nyx-example/issues"
+        },
+        "response": {
+          "bodySize": 2226,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2226,
+            "text": "{\"url\":\"https://api.github.com/repos/malleatus/nyx-example/issues/163\",\"repository_url\":\"https://api.github.com/repos/malleatus/nyx-example\",\"labels_url\":\"https://api.github.com/repos/malleatus/nyx-example/issues/163/labels{/name}\",\"comments_url\":\"https://api.github.com/repos/malleatus/nyx-example/issues/163/comments\",\"events_url\":\"https://api.github.com/repos/malleatus/nyx-example/issues/163/events\",\"html_url\":\"https://github.com/malleatus/nyx-example/issues/163\",\"id\":956172724,\"node_id\":\"MDU6SXNzdWU5NTYxNzI3MjQ=\",\"number\":163,\"title\":\"Nightly Run Failure: 123456\",\"user\":{\"login\":\"malleatus-user-alpha\",\"id\":63114387,\"node_id\":\"MDQ6VXNlcjYzMTE0Mzg3\",\"avatar_url\":\"https://avatars.githubusercontent.com/u/63114387?v=4\",\"gravatar_id\":\"\",\"url\":\"https://api.github.com/users/malleatus-user-alpha\",\"html_url\":\"https://github.com/malleatus-user-alpha\",\"followers_url\":\"https://api.github.com/users/malleatus-user-alpha/followers\",\"following_url\":\"https://api.github.com/users/malleatus-user-alpha/following{/other_user}\",\"gists_url\":\"https://api.github.com/users/malleatus-user-alpha/gists{/gist_id}\",\"starred_url\":\"https://api.github.com/users/malleatus-user-alpha/starred{/owner}{/repo}\",\"subscriptions_url\":\"https://api.github.com/users/malleatus-user-alpha/subscriptions\",\"organizations_url\":\"https://api.github.com/users/malleatus-user-alpha/orgs\",\"repos_url\":\"https://api.github.com/users/malleatus-user-alpha/repos\",\"events_url\":\"https://api.github.com/users/malleatus-user-alpha/events{/privacy}\",\"received_events_url\":\"https://api.github.com/users/malleatus-user-alpha/received_events\",\"type\":\"User\",\"site_admin\":false},\"labels\":[{\"id\":1924846368,\"node_id\":\"MDU6TGFiZWwxOTI0ODQ2MzY4\",\"url\":\"https://api.github.com/repos/malleatus/nyx-example/labels/CI\",\"name\":\"CI\",\"color\":\"ededed\",\"default\":false,\"description\":null}],\"state\":\"open\",\"locked\":false,\"assignee\":null,\"assignees\":[],\"milestone\":null,\"comments\":0,\"created_at\":\"2021-07-29T20:13:41Z\",\"updated_at\":\"2021-07-29T20:13:41Z\",\"closed_at\":null,\"author_association\":\"COLLABORATOR\",\"active_lock_reason\":null,\"body\":\"Nightly run failed on: 3 Apr 1994\\nhttps://github.com/malleatus/nyx-example/actions/runs/123456\",\"closed_by\":null,\"performed_via_github_app\":null}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "server",
+              "value": "GitHub.com"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 29 Jul 2021 20:13:41 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "content-length",
+              "value": "2226"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, max-age=60, s-maxage=60"
+            },
+            {
+              "name": "vary",
+              "value": "Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept, X-Requested-With"
+            },
+            {
+              "name": "etag",
+              "value": "\"632b5b87b07527c213e45a5aa93cda61425dcc453046df14c331562d7a36f937\""
+            },
+            {
+              "name": "x-oauth-scopes",
+              "value": "repo"
+            },
+            {
+              "name": "x-accepted-oauth-scopes",
+              "value": ""
+            },
+            {
+              "name": "location",
+              "value": "https://api.github.com/repos/malleatus/nyx-example/issues/163"
+            },
+            {
+              "name": "x-github-media-type",
+              "value": "github.v3; format=json"
+            },
+            {
+              "name": "x-ratelimit-limit",
+              "value": "5000"
+            },
+            {
+              "name": "x-ratelimit-remaining",
+              "value": "4998"
+            },
+            {
+              "name": "x-ratelimit-reset",
+              "value": "1627593110"
+            },
+            {
+              "name": "x-ratelimit-used",
+              "value": "2"
+            },
+            {
+              "name": "x-ratelimit-resource",
+              "value": "core"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubdomains; preload"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "deny"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "0"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "origin-when-cross-origin, strict-origin-when-cross-origin"
+            },
+            {
+              "name": "content-security-policy",
+              "value": "default-src 'none'"
+            },
+            {
+              "name": "x-github-request-id",
+              "value": "22F6:35D6:FE98E6:26CBB80:61030BF5"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 1305,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "https://api.github.com/repos/malleatus/nyx-example/issues/163",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "1994-04-03T13:14:00.000Z",
+        "time": 0,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 0
+        }
+      },
+      {
         "_id": "7ea576ba9e5934f4f85e64d724e858a9",
         "_order": 0,
         "cache": {},
@@ -166,356 +525,6 @@
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
-        },
-        "startedDateTime": "1994-04-03T13:14:00.000Z",
-        "time": 0,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 0
-        }
-      },
-      {
-        "_id": "846f6256233322fc8551387987972175",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "application/vnd.github.v3+json"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "@malleatus/nyx failure reporter octokit-rest.js/17.2.1 octokit-core.js/2.4.3 Node.js/12.16.1 (macOS Catalina; x64)"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "api.github.com"
-            }
-          ],
-          "headersSize": 481,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "q",
-              "value": "repo:malleatus/nyx-example state:open is:issue label:CI in:title Nightly Run Failure: 123456"
-            }
-          ],
-          "url": "https://api.github.com/search/issues?q=repo%3Amalleatus%2Fnyx-example%20state%3Aopen%20is%3Aissue%20label%3ACI%20in%3Atitle%20Nightly%20Run%20Failure%3A%20123456"
-        },
-        "response": {
-          "bodySize": 148,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 148,
-            "text": "[\"1f8b0800000000000003ab562ac92f49cc894fce2fcd2b51b232d051cacc4bcecf2dc8492d498d2f4a2d2ecd292956b24a4bcc294e054a95a4e60279d1b1b500c845f5b737000000\"]"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "server",
-              "value": "GitHub.com"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 20 Apr 2020 03:29:20 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "x-ratelimit-limit",
-              "value": "30"
-            },
-            {
-              "name": "x-ratelimit-remaining",
-              "value": "29"
-            },
-            {
-              "name": "x-ratelimit-reset",
-              "value": "1587353420"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "x-oauth-scopes",
-              "value": "repo"
-            },
-            {
-              "name": "x-accepted-oauth-scopes",
-              "value": ""
-            },
-            {
-              "name": "x-github-media-type",
-              "value": "github.v3; format=json"
-            },
-            {
-              "name": "access-control-expose-headers",
-              "value": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": "*"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubdomains; preload"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "deny"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "referrer-policy",
-              "value": "origin-when-cross-origin, strict-origin-when-cross-origin"
-            },
-            {
-              "name": "content-security-policy",
-              "value": "default-src 'none'"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding, Accept, X-Requested-With"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            },
-            {
-              "name": "x-github-request-id",
-              "value": "FD3C:6ED2:7DBBEE:D24055:5E9D1710"
-            }
-          ],
-          "headersSize": 1053,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "1994-04-03T13:14:00.000Z",
-        "time": 0,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 0
-        }
-      },
-      {
-        "_id": "23338d6c037407fc93437c1ada5aebb5",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 160,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "application/vnd.github.v3+json"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "@malleatus/nyx failure reporter octokit-rest.js/17.2.1 octokit-core.js/2.4.3 Node.js/12.16.1 (macOS Catalina; x64)"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "160"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "api.github.com"
-            }
-          ],
-          "headersSize": 446,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"title\":\"Nightly Run Failure: 123456\",\"body\":\"Nightly run failed on: 3 Apr 1994\\nhttps://github.com/malleatus/nyx-example/actions/runs/123456\",\"labels\":[\"CI\"]}"
-          },
-          "queryString": [],
-          "url": "https://api.github.com/repos/malleatus/nyx-example/issues"
-        },
-        "response": {
-          "bodySize": 2163,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 2163,
-            "text": "{\"url\":\"https://api.github.com/repos/malleatus/nyx-example/issues/81\",\"repository_url\":\"https://api.github.com/repos/malleatus/nyx-example\",\"labels_url\":\"https://api.github.com/repos/malleatus/nyx-example/issues/81/labels{/name}\",\"comments_url\":\"https://api.github.com/repos/malleatus/nyx-example/issues/81/comments\",\"events_url\":\"https://api.github.com/repos/malleatus/nyx-example/issues/81/events\",\"html_url\":\"https://github.com/malleatus/nyx-example/issues/81\",\"id\":602911577,\"node_id\":\"MDU6SXNzdWU2MDI5MTE1Nzc=\",\"number\":81,\"title\":\"Nightly Run Failure: 123456\",\"user\":{\"login\":\"malleatus-user-alpha\",\"id\":63114387,\"node_id\":\"MDQ6VXNlcjYzMTE0Mzg3\",\"avatar_url\":\"https://avatars2.githubusercontent.com/u/63114387?v=4\",\"gravatar_id\":\"\",\"url\":\"https://api.github.com/users/malleatus-user-alpha\",\"html_url\":\"https://github.com/malleatus-user-alpha\",\"followers_url\":\"https://api.github.com/users/malleatus-user-alpha/followers\",\"following_url\":\"https://api.github.com/users/malleatus-user-alpha/following{/other_user}\",\"gists_url\":\"https://api.github.com/users/malleatus-user-alpha/gists{/gist_id}\",\"starred_url\":\"https://api.github.com/users/malleatus-user-alpha/starred{/owner}{/repo}\",\"subscriptions_url\":\"https://api.github.com/users/malleatus-user-alpha/subscriptions\",\"organizations_url\":\"https://api.github.com/users/malleatus-user-alpha/orgs\",\"repos_url\":\"https://api.github.com/users/malleatus-user-alpha/repos\",\"events_url\":\"https://api.github.com/users/malleatus-user-alpha/events{/privacy}\",\"received_events_url\":\"https://api.github.com/users/malleatus-user-alpha/received_events\",\"type\":\"User\",\"site_admin\":false},\"labels\":[{\"id\":1924846368,\"node_id\":\"MDU6TGFiZWwxOTI0ODQ2MzY4\",\"url\":\"https://api.github.com/repos/malleatus/nyx-example/labels/CI\",\"name\":\"CI\",\"color\":\"ededed\",\"default\":false,\"description\":null}],\"state\":\"open\",\"locked\":false,\"assignee\":null,\"assignees\":[],\"milestone\":null,\"comments\":0,\"created_at\":\"2020-04-20T03:29:20Z\",\"updated_at\":\"2020-04-20T03:29:21Z\",\"closed_at\":null,\"author_association\":\"COLLABORATOR\",\"body\":\"Nightly run failed on: 3 Apr 1994\\nhttps://github.com/malleatus/nyx-example/actions/runs/123456\",\"closed_by\":null}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "server",
-              "value": "GitHub.com"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 20 Apr 2020 03:29:21 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "content-length",
-              "value": "2163"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "status",
-              "value": "201 Created"
-            },
-            {
-              "name": "x-ratelimit-limit",
-              "value": "5000"
-            },
-            {
-              "name": "x-ratelimit-remaining",
-              "value": "4946"
-            },
-            {
-              "name": "x-ratelimit-reset",
-              "value": "1587355055"
-            },
-            {
-              "name": "cache-control",
-              "value": "private, max-age=60, s-maxage=60"
-            },
-            {
-              "name": "vary",
-              "value": "Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept, X-Requested-With"
-            },
-            {
-              "name": "etag",
-              "value": "\"cd7fa10141a21d97c5b177cdddb05212\""
-            },
-            {
-              "name": "x-oauth-scopes",
-              "value": "repo"
-            },
-            {
-              "name": "x-accepted-oauth-scopes",
-              "value": ""
-            },
-            {
-              "name": "location",
-              "value": "https://api.github.com/repos/malleatus/nyx-example/issues/81"
-            },
-            {
-              "name": "x-github-media-type",
-              "value": "github.v3; format=json"
-            },
-            {
-              "name": "access-control-expose-headers",
-              "value": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": "*"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubdomains; preload"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "deny"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "referrer-policy",
-              "value": "origin-when-cross-origin, strict-origin-when-cross-origin"
-            },
-            {
-              "name": "content-security-policy",
-              "value": "default-src 'none'"
-            },
-            {
-              "name": "x-github-request-id",
-              "value": "FD47:5C97:7C952A:CAE18E:5E9D1710"
-            }
-          ],
-          "headersSize": 1215,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "https://api.github.com/repos/malleatus/nyx-example/issues/81",
-          "status": 201,
-          "statusText": "Created"
         },
         "startedDateTime": "1994-04-03T13:14:00.000Z",
         "time": 0,

--- a/src/commands/report-failure.ts
+++ b/src/commands/report-failure.ts
@@ -2,8 +2,10 @@
 import { Octokit } from '@octokit/rest';
 import m from 'moment';
 
+const IssuePrefix = 'Nightly Run Failure';
+
 function getIssueTitle(runId: string): string {
-  return `Nightly Run Failure: ${runId}`;
+  return `${IssuePrefix}: ${runId}`;
 }
 
 interface CreateIssueArgs {
@@ -48,10 +50,9 @@ export default async function reportFailure({
     userAgent: '@malleatus/nyx failure reporter',
   });
 
-  const issueTitle = getIssueTitle(runId);
   // https://help.github.com/en/github/searching-for-information-on-github/searching-issues-and-pull-requests
   const issueSearch = await github.search.issuesAndPullRequests({
-    q: `repo:${owner}/${repo} state:open is:issue label:CI in:title ${issueTitle}`,
+    q: `repo:${owner}/${repo} state:open is:issue label:CI in:title "${IssuePrefix}"`,
   });
 
   if (issueSearch.data.total_count > 0) {


### PR DESCRIPTION
Previously nightly issues were searched with a string that included the run id, so we never found existing issues and just kept creating new ones.
